### PR TITLE
corrected path to tests in instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -383,8 +383,8 @@ for most of the above settings available in the link:tests/[tests directory].
 ----
 sudo apt-get -y install bats
 git clone https://github.com/konstruktoid/hardening.git
-cd tests/
-sudo bats .
+cd hardening/tests/
+sudo bats . #note the '.'
 ----
 
 === Test automation using Vagrant


### PR DESCRIPTION
//reference
"cd repo.git" #note from @swipswaps: Even github.com gets this step wrong . . .
//source: https://help.github.com/en/github/importing-your-projects-to-github/importing-a-git-repository-using-the-command-line