### PR TITLE
remove net.ipv4.tcp_timestamps

### DIFF
--- a/misc/sysctl.conf
+++ b/misc/sysctl.conf
@@ -45,7 +45,6 @@ net.ipv4.tcp_rfc1337 = 1
 net.ipv4.tcp_syn_retries = 5
 net.ipv4.tcp_synack_retries = 2
 net.ipv4.tcp_syncookies = 1
-net.ipv4.tcp_timestamps = 0
 net.ipv6.conf.all.accept_ra = 0
 net.ipv6.conf.all.accept_redirects = 0
 net.ipv6.conf.all.accept_source_route = 0

--- a/tests/sysctl.bats
+++ b/tests/sysctl.bats
@@ -202,11 +202,6 @@ load test_helper
   [ "$status" -eq 0 ]
 }
 
-@test "Verify net.ipv4.tcp_timestamps in /etc/sysctl.*" {
-  run bash -c "grep -R '^net.ipv4.tcp_timestamps.*0$' /etc/sysctl.*"
-  [ "$status" -eq 0 ]
-}
-
 @test "Verify net.ipv6.conf.all.use_tempaddr in /etc/sysctl.*" {
   run bash -c "grep -R '^net.ipv6.conf.all.use_tempaddr.*2$' /etc/sysctl.*"
   [ "$status" -eq 0 ]
@@ -463,11 +458,6 @@ load test_helper
 
 @test "Verify sysctl runtime net.ipv4.tcp_syn_retries" {
   run sysctlRuntime '^net.ipv4.tcp_syn_retries.*5$'
-  [ "$status" -eq 0 ]
-}
-
-@test "Verify sysctl runtime net.ipv4.tcp_timestamps" {
-  run sysctlRuntime '^net.ipv4.tcp_timestamps.*0$'
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Use the net.ipv4.tcp_timestamps defaults

Ref #129 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>