### PR TITLE
aide.wrapper not present in jammy

### DIFF
--- a/config/aidecheck.service
+++ b/config/aidecheck.service
@@ -3,7 +3,7 @@ Description=Aide Check
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/aide.wrapper --check
+ExecStart=/usr/bin/aide --check --config /etc/aide/aide.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Use `/usr/bin/aide --check --config /etc/aide/aide.conf` since `aide.wrapper` has been removed in jammy.

closes #196

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>