### PR TITLE
grep the correct file names

### DIFF
--- a/tests/runHostTests.sh
+++ b/tests/runHostTests.sh
@@ -5,7 +5,7 @@ if ! command -v bats 1>/dev/null; then
   exit 1
 fi
 
-TESTS="$(grep -Ro '@test' ./*_*.bats | wc -l)"
+TESTS="$(grep -Ro '@test' ./*.bats | wc -l)"
 HOST="$(hostname -s)"
 
 sudo bats . | tee ./"${HOST}-bats.log" 1>/dev/null


### PR DESCRIPTION
The `.bats` files had their names changed a while back, this PR fixes the test script.

Closes #246 