### PR TITLE
Restrict unprivileged user namespace creation

### DIFF
--- a/misc/sysctl.conf
+++ b/misc/sysctl.conf
@@ -19,6 +19,7 @@ kernel.perf_event_paranoid = 3
 kernel.randomize_va_space = 2
 kernel.sysrq = 0
 kernel.unprivileged_bpf_disabled = 1
+kernel.unprivileged_userns_clone = 1
 kernel.yama.ptrace_scope = 2
 net.core.bpf_jit_harden = 2
 net.ipv4.conf.all.accept_redirects = 0


### PR DESCRIPTION
This pull request adds the `kernel.unprivileged_userns_clone = 1` option to the `sysctl.conf` configuration file. This option restricts the creation of unprivileged user namespaces, which helps to enhance the security of the system.

By enabling this option, we prevent unprivileged users from creating their own user namespaces, which could potentially be used to bypass security controls and access system resources that they would not normally have access to. This is especially important in environments where users have limited privileges but need to run untrusted or potentially malicious code.